### PR TITLE
Add pkgdown site

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -2,3 +2,6 @@
 ^\.Rproj\.user$
 ^website$
 ^License\.md$
+^_pkgdown\.yml$
+^docs$
+^pkgdown$

--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@
 .DS_Store
 /.quarto/
 /_site/
+docs

--- a/pkgdown/_pkgdown.yml
+++ b/pkgdown/_pkgdown.yml
@@ -1,0 +1,7 @@
+url: schiano-noaa.github.io/ASAR/
+
+home:
+  title: Automated Stock Assessment Reporting
+
+template:
+  bootstrap: 5

--- a/pkgdown/extra.css
+++ b/pkgdown/extra.css
@@ -1,0 +1,1 @@
+@import url("https://nmfs-fish-tools.github.io/nmfspalette/extra.css");


### PR DESCRIPTION
This PR contributes the development of the pkgdown site for the R package by

- creating a pkgdown config file and updating `.Rbuildignore` and `.gitignore` fires
- adding an extra.css file to import HTML styles from {nmfspalette}

To render the website locally, go to the `add-pkgdown-site` branch and run `pkgdown::build_site()`

