### PR TITLE
Add TOC to pdf bookmarks

### DIFF
--- a/inst/resources/formatting_files/before-body.tex
+++ b/inst/resources/formatting_files/before-body.tex
@@ -11,3 +11,5 @@ $else$
 $endif$
 
 \newgeometry{top=1in,bottom=1in,right=1in,left=1in}
+
+\pdfbookmark[1]{Table of Contents}{toc}


### PR DESCRIPTION
<!---
Thanks for opening a PR. This commented text will **NOT** appear in the final PR. Toggle between Write and Preview to see what your PR will look like without the comments.
-->

# What is the feature?
* Add TOC to pdf bookmarks, in response to Brian's question ("Is there a way to tag the Table of Contents so that it appears within the bookmarks section of the document? Right now the first bookmark I have is the Executive Summary.")

# How have you implemented the solution?
* Adding a line to a latex partial

# Does the PR impact any other area of the project, maybe another repo?
* No