### PR TITLE
HOTFIX: Fix blank figures_doc created in create_template()

### DIFF
--- a/R/create_template.R
+++ b/R/create_template.R
@@ -608,7 +608,7 @@ create_template <- function(
         "safe" = "12_figures.qmd",
         "09_figures.qmd"
       )
-      figures_doc <- ""
+      figures_doc <- "# Figures {#sec-figures}\n \n"
       utils::capture.output(cat(figures_doc),
         file = fs::path(subdir, figures_doc_name),
         append = FALSE


### PR DESCRIPTION
<!---
Thanks for opening a PR. This commented text will **NOT** appear in the final PR. Toggle between Write and Preview to see what your PR will look like without the comments.
-->

# What is the feature?
* Fix blank figures_doc created in create_template() so that it includes a header; otherwise, the figures in this doc were put into the Tables section

# Does the PR impact any other area of the project, maybe another repo?
* No
