### PR TITLE
Replace rda item label "cap" with "caption", for clarity

### DIFF
--- a/R/create_figures_doc.R
+++ b/R/create_figures_doc.R
@@ -76,7 +76,7 @@ load(file.path(figures_dir, '", fig, "'))\n
 rm(rda)\n
 # save figure, caption, and alt text as separate objects
 ", fig_shortname, "_plot <- ", fig_shortname, "_plot_rda$figure
-", fig_shortname, "_cap <- ", fig_shortname, "_plot_rda$cap
+", fig_shortname, "_cap <- ", fig_shortname, "_plot_rda$caption
 ", fig_shortname, "_alt_text <- ", fig_shortname, "_plot_rda$alt_text"
         ),
         label = glue::glue("fig-{fig_shortname}-setup")

--- a/R/create_tables_doc.R
+++ b/R/create_tables_doc.R
@@ -139,7 +139,7 @@ load(file.path(tables_dir, '", stringr::str_remove(tab, "_split"), "'))\n
           tab_shortname, "_table_rda <- rda\n
 # save table and caption as separate objects\n",
           tab_shortname, "_table <- ", tab_shortname, "_table_rda$table\n",
-          tab_shortname, "_cap <- ", tab_shortname, "_table_rda$cap"
+          tab_shortname, "_cap <- ", tab_shortname, "_table_rda$caption"
         ),
         label = glue::glue("tab-{tab_shortname}-setup")
       ),

--- a/tests/testthat/test-ID_tbl_width_class.R
+++ b/tests/testthat/test-ID_tbl_width_class.R
@@ -11,7 +11,7 @@ test_that("Table widths calculated correctly for wide table", {
 
   rda <- list(
     "table" = test_table,
-    "cap" = "test_caption"
+    "caption" = "test_caption"
   )
 
   tbl_path <- fs::path(getwd(), "tables")
@@ -66,7 +66,7 @@ test_that("Table widths calculated correctly for extra-wide table", {
 
   rda <- list(
     "table" = test_table,
-    "cap" = "test_caption"
+    "caption" = "test_caption"
   )
 
   tbl_path <- fs::path(getwd(), "tables")

--- a/vignettes/accessibility_guide.Rmd
+++ b/vignettes/accessibility_guide.Rmd
@@ -179,9 +179,9 @@ recruitment_alt_text <- new_alt_text
 
 **NOTES**:
 
-1.  Changes to your alt text will be saved within your 09_figures.qmd file, but not within the rda file itself. To directly edit the rda file's alt text or caption, assign a new value to the text you wish to change. For example, if your rda is called `rda` and you want to change the caption to "my new caption", you'd enter the following command: `rda[["cap"]] <- "my new caption"`. To change the alt text, you'd change "cap" to "alt_text" (e.g., `rda[["alt_text"]] <- "my new alt text"`.). Save the changes to the rda's file by entering the following command (in this example, our rda is called "biomass_figure.rda"): `save(rda, file = 'biomass_figure.rda')`.
+1.  Changes to your alt text will be saved within your 09_figures.qmd file, but not within the rda file itself. To directly edit the rda file's alt text or caption, assign a new value to the text you wish to change. For example, if your rda is called `rda` and you want to change the caption to "my new caption", you'd enter the following command: `rda[["caption"]] <- "my new caption"`. To change the alt text, you'd change "caption" to "alt_text" (e.g., `rda[["alt_text"]] <- "my new alt text"`.). Save the changes to the rda's file by entering the following command (in this example, our rda is called "biomass_figure.rda"): `save(rda, file = 'biomass_figure.rda')`.
 
-2.  Edit figure and table captions with the same process. Just substitute mentions of alt text with caption or cap, depending on the context.
+2.  Edit figure and table captions with the same process. Just substitute mentions of alt text with caption.
 
 3.  As stated earlier, if you see text that looks like a placeholder (e.g., "The x axis, showing the year, spans from B.start.year to B.end.year..."), that means that there was at least one instance where our tool failed to extract a specific value from the model results and substitute it into the placeholder. Please make sure that your alt text and captions contain the expected values before moving forward with your report. Check out the inst/resources/captions_alt_text_template.csv file in the `stockplotr` package to view the template with placeholders. The same package's `write_captions()` function shows how values are extracted from the model results and substituted into the placeholders.
 

--- a/vignettes/custom-figs-tabs.Rmd
+++ b/vignettes/custom-figs-tabs.Rmd
@@ -237,7 +237,7 @@ Your rdas will contain your table or figure, caption, and alternative text (if i
 ```{r eval=F}
 rda <- list(
   "table" = your_table, # your table object
-  "cap" = my_table_cap # your table caption
+  "caption" = my_table_cap # your table caption
 )
 ```
 
@@ -246,7 +246,7 @@ rda <- list(
 ```{r eval=F}
 rda <- list(
   "figure" = your_figure, # your figure object
-  "cap" = my_figure_cap, # your figure caption
+  "caption" = my_figure_cap, # your figure caption
   "alt_text" = my_figure_alt_text # your figure alternative text
 )
 ```
@@ -504,7 +504,7 @@ rm(rda)
 
 # save table, caption as separate objects
 example_table <- example_table_rda$table
-example_cap <- example_table_rda$cap
+example_cap <- example_table_rda$caption
 ``` 
 ````
 
@@ -547,7 +547,7 @@ rm(rda)
 
 # save table, caption as separate objects
 example_table <- example_table_rda$table
-example_cap <- example_table_rda$cap
+example_cap <- example_table_rda$caption
 ``` 
 ````
 
@@ -609,7 +609,7 @@ example_table_rda <- rda
 rm(rda)
 
 # save caption as separate object
-example_cap <- example_table_rda$cap
+example_cap <- example_table_rda$caption
 
 # load split table rda and save with a table-specific name, then delete "table_list"
 load(file.path(tables_dir, "example_table_split.rda"))
@@ -690,7 +690,7 @@ rm(rda)
 
 # save figure, caption, and alternative text as separate objects
 example_plot <- example_figure_rda$figure
-example_cap <- example_figure_rda$cap
+example_cap <- example_figure_rda$caption
 example_alt_text <- example_figure_rda$alt_text
 ``` 
 ````


### PR DESCRIPTION
<!---
Thanks for opening a PR. This commented text will **NOT** appear in the final PR. Toggle between Write and Preview to see what your PR will look like without the comments.
-->

# What is the feature?
* Replace rda item label "cap" with "caption", for clarity

# How have you implemented the solution?
* Replacing "cap" with "caption" in appropriate locations

# Does the PR impact any other area of the project, maybe another repo?
* This PR should be merged into main at the same time as [this `stockplotr` PR](https://github.com/nmfs-ost/stockplotr/pull/161)