### PR TITLE
Fix figure caption extraction

### DIFF
--- a/R/create_figures_doc.R
+++ b/R/create_figures_doc.R
@@ -76,7 +76,7 @@ load(file.path(figures_dir, '", fig, "'))\n
 rm(rda)\n
 # save figure, caption, and alt text as separate objects
 ", fig_shortname, "_plot <- ", fig_shortname, "_plot_rda$figure
-", fig_shortname, "_cap <- ", fig_shortname, "_plot_rda$cap
+", fig_shortname, "_cap <- ", fig_shortname, "_plot_rda$caption
 ", fig_shortname, "_alt_text <- ", fig_shortname, "_plot_rda$alt_text"
         ),
         label = glue::glue("fig-{fig_shortname}-setup")


### PR DESCRIPTION


<!---
Thanks for opening a PR. This commented text will **NOT** appear in the final PR. Toggle between Write and Preview to see what your PR will look like without the comments.
-->

# What is the feature?
* Fix figure caption extraction as per https://github.com/nmfs-ost/asar/issues/396

# How have you implemented the solution?
* Changing caption's object name

# Does the PR impact any other area of the project, maybe another repo?
* Coincides with https://github.com/nmfs-ost/stockplotr/pull/161 and https://github.com/nmfs-ost/asar/pull/394