### PR TITLE
Fix create_tables/figures_doc() bug occurring if user appends plots to empty docs

### DIFF
--- a/R/create_figures_doc.R
+++ b/R/create_figures_doc.R
@@ -31,6 +31,10 @@ create_figures_doc <- function(subdir = getwd(),
     if ("# Figures {#sec-figures}" %in% figure_content) {
       append <- TRUE
       cli::cli_alert_info("Figures doc will be appended to include figures in `figures_dir`.")
+  
+    # remove empty_doc_text
+    updated_content <- gsub(empty_doc_text, "", figure_content, fixed = TRUE)
+    writeLines(updated_content, existing_figs_doc)
     }
   }
 
@@ -203,7 +207,7 @@ rm(rda)\n
     ),
     append = append
   )
-
+  
   # Read through figures doc and warn about identical labels
   new_figs_doc <- readLines(
     ifelse(

--- a/R/create_tables_doc.R
+++ b/R/create_tables_doc.R
@@ -60,6 +60,10 @@ create_tables_doc <- function(subdir = getwd(),
     if ("# Tables {#sec-tables}" %in% table_content) {
       append <- TRUE
       cli::cli_alert_info("Tables doc will be appended to include tables in `tables_dir`.")
+      
+      # remove empty_doc_text
+      updated_content <- gsub(empty_doc_text, "", table_content, fixed = TRUE)
+      writeLines(updated_content, existing_tables_doc)
     }
   }
 

--- a/tests/testthat/test-create_figures_doc.R
+++ b/tests/testthat/test-create_figures_doc.R
@@ -68,6 +68,50 @@ test_that("Creates expected start of figures doc with figure", {
   unlink(fs::path(getwd(), "figures"), recursive = T)
 })
 
+test_that("Formerly empty figures doc renders correctly", {
+  # create empty figures doc
+  create_template()
+  
+  # load sample dataset
+  load(file.path(
+    "fixtures", "ss3_models_converted", "Hake_2018",
+    "std_output.rda"
+  ))
+  
+  stockplotr::plot_biomass(
+    dat = out_new,
+    make_rda = TRUE,
+    module = "TIME_SERIES"
+  )
+  
+  # rerender figures doc, appending new figure
+  create_figures_doc(
+    subdir = file.path(getwd(), "report"),
+    figures_dir = getwd()
+  )
+  
+  # read in figures doc
+  figure_content <- readLines(file.path(getwd(), "report", "09_figures.qmd"))
+  # extract first 8 lines
+  head_figure_content <- head(figure_content, 8)
+  # remove line numbers and collapse
+  fc_pasted <- paste(head_figure_content, collapse = "")
+  
+  # expected figures doc head
+  expected_head_figure_content <- "# Figures {#sec-figures} ```{r} #| label: 'set-rda-dir-figs'#| echo: false #| warnings: false #| eval: true"
+  
+  # test expectation of start of figures doc
+  expect_equal(
+    fc_pasted,
+    expected_head_figure_content
+  )
+  
+  # erase temporary testing files
+  file.remove(fs::path(getwd(), "09_figures.qmd"))
+  file.remove(fs::path(getwd(), "captions_alt_text.csv"))
+  unlink(fs::path(getwd(), "figures"), recursive = T)
+  unlink(fs::path(getwd(), "report"), recursive = T)
+})
 
 test_that("Throws warning if chunks with identical labels", {
   # load sample dataset

--- a/tests/testthat/test-create_tables_doc.R
+++ b/tests/testthat/test-create_tables_doc.R
@@ -96,3 +96,48 @@ test_that("Creates expected start of nearly empty tables doc", {
 #   file.remove(fs::path(getwd(), "captions_alt_text.csv"))
 #   unlink(fs::path(getwd(), "tables"), recursive = T)
 # })
+
+# test_that("Formerly empty tables doc renders correctly", {
+#   # create empty tables doc
+#   create_template()
+#   
+#   # load sample dataset
+#   load(file.path(
+#     "fixtures", "ss3_models_converted", "Hake_2018",
+#     "std_output.rda"
+#   ))
+#   
+#   stockplotr::table_landings(
+#     dat = out_new,
+#     make_rda = TRUE,
+#     module = "TIME_SERIES"
+#   )
+#   
+#   # rerender tables doc, appending new table
+#   create_tables_doc(
+#     subdir = file.path(getwd(), "report"),
+#     tables_dir = getwd()
+#   )
+#   
+#   # read in tables doc
+#   table_content <- readLines(file.path(getwd(), "report", "08_tables.qmd"))
+#   # extract first 8 lines
+#   head_table_content <- head(table_content, 8)
+#   # remove line numbers and collapse
+#   fc_pasted <- paste(head_table_content, collapse = "")
+#   
+#   # expected tables doc head
+#   expected_head_table_content <- "# Tables {#sec-tables} ```{r} #| label: 'set-rda-dir-figs'#| echo: false #| warnings: false #| eval: true"
+#   
+#   # test expectation of start of tables doc
+#   expect_equal(
+#     fc_pasted,
+#     expected_head_table_content
+#   )
+#   
+#   # erase temporary testing files
+#   file.remove(fs::path(getwd(), "08_tables.qmd"))
+#   file.remove(fs::path(getwd(), "captions_alt_text.csv"))
+#   unlink(fs::path(getwd(), "tables"), recursive = T)
+#   unlink(fs::path(getwd(), "report"), recursive = T)
+# })


### PR DESCRIPTION


<!---
Thanks for opening a PR. This commented text will **NOT** appear in the final PR. Toggle between Write and Preview to see what your PR will look like without the comments.
-->

# What is the feature?
* Fix bug so that, if the user runs create_tables/figures_doc() after already creating an empty tables/figures doc, the text signifying the doc as empty is removed; add tests

# How have you implemented the solution?
* Removing the text signifying the doc as empty, if append = TRUE

# Does the PR impact any other area of the project, maybe another repo?
* No
