### PR TITLE
change action so only comments when the PR is first opened

### DIFF
--- a/.github/workflows/new-version-checklist.yml
+++ b/.github/workflows/new-version-checklist.yml
@@ -4,6 +4,7 @@ name: new-version-checklist
 on:
   pull_request:
     branches: [main]
+    types: [opened]
   workflow_dispatch:
 jobs:
   new-version-checklist:


### PR DESCRIPTION
<!---
Thanks for opening a PR. This commented text will **NOT** appear in the final PR. Toggle between Write and Preview to see what your PR will look like without the comments.
-->

# What is the feature?
* Adjust the GH action when a PR is opened to main the comment is no longer repeated for each commit pushed rather just when opening

# How have you implemented the solution?
* Added line to change on opening

# Does the PR impact any other area of the project, maybe another repo?
* no
