### PR TITLE
Shorten glossary labels by subbing FSC acronyms in for full names

### DIFF
--- a/R/export_glossary.R
+++ b/R/export_glossary.R
@@ -792,6 +792,15 @@ export_glossary <- function() {
     ) |>
     dplyr::arrange(tolower(Label))
 
+  cat(paste0(
+    "% NOTE ON SURVEYS:\n",
+    "% To increase findability, surveys may have multiple entries to link informal with formal names.\n",
+    "% Specifically, there may be more than one 'label' (first curly braces entry) or 'acronym' (second curly braces entry) with the same 'long form' (third curly braces entry).\n",
+    "% If the first 'label' you find for a given survey seems too long, look for an alternative entry with the same 'long form' but a different 'label' and/or 'acronym'.\n",
+    "% For example, there are three entries for the 'long form' 'Northeast Ecosystem Monitoring (EcoMon)\\_Fall':\n\n",
+    "%     \\newacronym{ecomon fall}{ECOMON Fall}{Northeast Ecosystem Monitoring (EcoMon)\\_Fall}\n",
+    "%     \\newacronym{fall nefsc ecosystem monitoring survey}{Fall Northeast Fisheries Science Center Ecosystem Monitoring Survey}{Northeast Ecosystem Monitoring (EcoMon)\\_Fall}\n",
+    "%     \\newacronym{nemef}{NEMEF}{Northeast Ecosystem Monitoring (EcoMon)\\_Fall}\n\n"))
 
   for (i in 1:dim(tex_acs)[1]) {
     cat(

--- a/R/export_glossary.R
+++ b/R/export_glossary.R
@@ -672,7 +672,15 @@ export_glossary <- function() {
       Label,
       "[\\(\\)]",
       "-"
-    ))
+    )) |>
+    # make labels shorter by subbing FSCs acronyms
+    dplyr::mutate(
+      Label = gsub("alaska fisheries science center", "afsc", Label, ignore.case = TRUE),
+      Label = gsub("northeast fisheries science center", "nefsc", Label, ignore.case = TRUE),
+      Label = gsub("northwest fisheries science center", "nwfsc", Label, ignore.case = TRUE),
+      Label = gsub("pacific islands fisheries science center", "pifsc", Label, ignore.case = TRUE),
+      Label = gsub("southeast fisheries science center", "sefsc", Label, ignore.case = TRUE),
+      Label = gsub("southwest fisheries science center", "swfsc", Label, ignore.case = TRUE))
 
   duplicate_acronyms <- unique_all_cleaning3 |>
     dplyr::add_count(Acronym) |>

--- a/inst/glossary/report_glossary.tex
+++ b/inst/glossary/report_glossary.tex
@@ -1,3 +1,13 @@
+% NOTE ON SURVEYS:
+% To increase findability, surveys may have multiple entries to link informal with formal names.
+% Specifically, there may be more than one 'label' (first curly braces entry) or 'acronym' (second curly braces entry) with the same 'long form' (third curly braces entry).
+% If the first 'label' you find for a given survey seems too long, look for an alternative entry with the same 'long form' but a different 'label' and/or 'acronym'.
+% For example, there are three entries for the 'long form' 'Northeast Ecosystem Monitoring (EcoMon)\_Fall':
+
+%     \newacronym{ecomon fall}{ECOMON Fall}{Northeast Ecosystem Monitoring (EcoMon)\_Fall}
+%     \newacronym{fall nefsc ecosystem monitoring survey}{Fall Northeast Fisheries Science Center Ecosystem Monitoring Survey}{Northeast Ecosystem Monitoring (EcoMon)\_Fall}
+%     \newacronym{nemef}{NEMEF}{Northeast Ecosystem Monitoring (EcoMon)\_Fall}
+
 \newacronym{aa}{AA}{annual allocation}
 \newacronym{aac}{AAC}{Alaska Administrative Code}
 \newacronym{abc}{ABC}{acceptable biological catch}

--- a/inst/glossary/report_glossary.tex
+++ b/inst/glossary/report_glossary.tex
@@ -303,7 +303,7 @@
 \newacronym{fall juvenile fish survey in the southeastern bering sea and gulf of alaska}{Fall Juvenile Fish Survey in the Southeastern Bering Sea and Gulf of Alaska}{EMA Eastern Bering Sea Juvenile Fish\_Fall}
 \newacronym{fall juvenile survey}{Fall juvenile survey}{EMA Eastern Bering Sea Juvenile Fish\_Fall}
 \newacronym{fall maine - new hampshire inshore trawl survey}{Fall Maine - New Hampshire Inshore Trawl Survey}{NH/ME Inshore Trawl Survey\_Fall}
-\newacronym{fall northeast fisheries science center ecosystem monitoring survey}{Fall Northeast Fisheries Science Center Ecosystem Monitoring Survey}{Northeast Ecosystem Monitoring (EcoMon)\_Fall}
+\newacronym{fall nefsc ecosystem monitoring survey}{Fall Northeast Fisheries Science Center Ecosystem Monitoring Survey}{Northeast Ecosystem Monitoring (EcoMon)\_Fall}
 \newacronym{fao}{FAO}{Food \& Agriculture Organization of the United Nations}
 \newacronym{fate}{FATE}{Fisheries and the Environment}
 \newacronym{fcurrent}{$F_{current}$}{current fishing mortality rate}
@@ -612,7 +612,11 @@
 \newacronym{neamap spring}{NEAMAP Spring}{Northeast Area Monitoring and Assessment Program (NEAMAP)\_Spring (MDMR/VIMS)}
 \newacronym{nefmc}{NEFMC}{New England Fishery Management Council}
 \newacronym{nefsc}{NEFSC}{Northeast Fisheries Science Center}
+\newacronym{nefsc atlantic surfclam and ocean quahog survey}{Northeast Fisheries Science Center Atlantic surfclam and Ocean Quahog Survey}{Atlantic Surf Clam \& Ocean Quahog Dredge}
+\newacronym{nefsc fall bottom trawl survey}{Northeast Fisheries Science Center Fall Bottom Trawl Survey}{Bottom Trawl Survey\_Fall}
 \newacronym{nefsc shrimp}{NEFSC Shrimp}{Gulf of Maine Northern Shrimp Survey}
+\newacronym{nefsc shrimp survey}{Northeast Fisheries Science Center Shrimp Survey}{Gulf of Maine Northern Shrimp Survey}
+\newacronym{nefsc spring bottom trawl survey}{Northeast Fisheries Science Center Spring Bottom Trawl Survey}{Bottom Trawl Survey\_Spring}
 \newacronym{nefsc winter bottom trawl survey}{NEFSC Winter Bottom Trawl Survey}{Northeast Fisheries Science Center Winter Bottom Trawl Survey}
 \newacronym{nelha}{NELHA}{Natural Energy Laboratory of Hawaii Authority}
 \newacronym{nelss}{NELSS}{New Hampshire American Lobster Settlement Survey}
@@ -660,17 +664,11 @@
 \newacronym{north pacific right whale-summer}{North Pacific Right Whale-Summer}{CAEP Gulf of Alaska North Pacific Right Whale\_Summer}
 \newacronym{northeast area monitoring and assessment program -fall-}{Northeast Area Monitoring and Assessment Program (Fall)}{Northeast Area Monitoring and Assessment Program (NEAMAP)\_Fall (MDMR/VIMS)}
 \newacronym{northeast area monitoring and assessment program -spring-}{Northeast Area Monitoring and Assessment Program (Spring)}{Northeast Area Monitoring and Assessment Program (NEAMAP)\_Spring (MDMR/VIMS)}
-\newacronym{northeast fisheries science center atlantic surfclam and ocean quahog survey}{Northeast Fisheries Science Center Atlantic surfclam and Ocean Quahog Survey}{Atlantic Surf Clam \& Ocean Quahog Dredge}
-\newacronym{northeast fisheries science center fall bottom trawl survey}{Northeast Fisheries Science Center Fall Bottom Trawl Survey}{Bottom Trawl Survey\_Fall}
-\newacronym{northeast fisheries science center shrimp survey}{Northeast Fisheries Science Center Shrimp Survey}{Gulf of Maine Northern Shrimp Survey}
-\newacronym{northeast fisheries science center spring bottom trawl survey}{Northeast Fisheries Science Center Spring Bottom Trawl Survey}{Bottom Trawl Survey\_Spring}
 \newacronym{northern bering sea bottom trawl survey}{Northern Bering Sea Bottom Trawl Survey}{GAP-SAP Northern Bering Sea Bottom Trawl\_Summer}
 \newacronym{northern bering sea ecosystem survey}{Northern Bering Sea Ecosystem Survey}{EMA Northern Bering Sea Ecosystem Surface Trawl\_Fall}
 \newacronym{northern bering sea shelf bottom trawl survey}{Northern Bering Sea Shelf Bottom Trawl Survey}{GAP-SAP Northern Bering Sea Bottom Trawl\_Summer}
 \newacronym{northern california current -ncc- ecosystem forecasting-fall -across fy-}{$Northern California _{current} (NCC) Ecosystem Forecasting-Fall (across FY)$}{Northern California Current (NCC) Ecosystem Forecasting\_Fall}
 \newacronym{northern california current -ncc- ecosystem forecasting-summer}{$Northern California _{current} (NCC) Ecosystem Forecasting-Summer$}{Northern California Current (NCC) Ecosystem Forecasting Survey -- Spring Upwelling Season Survey}
-\newacronym{northwest fisheries science center hook and line survey}{Northwest Fisheries Science Center Hook and Line Survey}{West Coast Rockfish Hook and Line}
-\newacronym{northwest fisheries science center west coast groundfish bottom trawl survey}{Northwest Fisheries Science Center West Coast Groundfish Bottom Trawl Survey}{West Coast Groundfish Bottom Trawl}
 \newacronym{nos}{NOS}{National Ocean Service}
 \newacronym{nova}{NOVA}{Notice Of Violation and Assessment}
 \newacronym{npafc}{NPAFC}{North Pacific Anadromous Fish Commission}
@@ -689,6 +687,8 @@
 \newacronym{nsrkc}{NSRKC}{Norton Sound Red King Crab}
 \newacronym{nsss}{NSSS}{Northeast Sea Scallop\_Summer}
 \newacronym{nwfsc}{NWFSC}{Northwest Fisheries Science Center}
+\newacronym{nwfsc hook and line survey}{Northwest Fisheries Science Center Hook and Line Survey}{West Coast Rockfish Hook and Line}
+\newacronym{nwfsc west coast groundfish bottom trawl survey}{Northwest Fisheries Science Center West Coast Groundfish Bottom Trawl Survey}{West Coast Groundfish Bottom Trawl}
 \newacronym{nwhi}{NWHI}{Northwestern Hawaiian Islands}
 \newacronym{nwifc}{NWIFC}{Northwest Indian Fisheries Commission}
 \newacronym{nwr}{NWR}{National Wildlife Refuge}
@@ -976,7 +976,7 @@
 \newacronym{spring california cooperative fisheries investigations survey}{Spring California Cooperative Fisheries Investigations Survey}{CalCOFI\_Spring}
 \newacronym{spring ct lists}{Spring CT LISTS}{Spring Connecticut Department of Energy and Environmental Protection Marine Fisheries Program Long Island Sound Trawl Survey}
 \newacronym{spring maine - new hampshire inshore trawl survey}{Spring Maine - New Hampshire Inshore Trawl Survey}{NH/ME Inshore Trawl Survey\_Spring}
-\newacronym{spring northeast fisheries science center ecosystem monitoring survey}{Spring Northeast Fisheries Science Center Ecosystem Monitoring Survey}{Northeast Ecosystem Monitoring (EcoMon)\_Spring}
+\newacronym{spring nefsc ecosystem monitoring survey}{Spring Northeast Fisheries Science Center Ecosystem Monitoring Survey}{Northeast Ecosystem Monitoring (EcoMon)\_Spring}
 \newacronym{sps}{SPS}{SEAMAP Plankton\_Spring}
 \newacronym{srd}{SRD}{science and research director}
 \newacronym{srdblsp}{SRDBLSP}{SEAMAP-SA Red Drum Bottom Longline Survey (partner)}
@@ -1018,7 +1018,7 @@
 \newacronym{summer acoustic-trawl survey}{Summer Acoustic-Trawl Survey}{MACE Eastern Bering Sea Pollock Acoustic Trawl\_Summer}
 \newacronym{summer calcofi}{Summer CalCOFI}{CalCOFI\_Summer}
 \newacronym{summer california cooperative fisheries investigations survey}{Summer California Cooperative Fisheries Investigations Survey}{CalCOFI\_Summer}
-\newacronym{summer northeast fisheries science center ecosystem monitoring survey}{Summer Northeast Fisheries Science Center Ecosystem Monitoring Survey}{Northeast Ecosystem Monitoring (EcoMon)\_Summer}
+\newacronym{summer nefsc ecosystem monitoring survey}{Summer Northeast Fisheries Science Center Ecosystem Monitoring Survey}{Northeast Ecosystem Monitoring (EcoMon)\_Summer}
 \newacronym{summer pollock survey}{Summer Pollock Survey}{MACE Eastern Bering Sea Pollock Acoustic Trawl\_Summer}
 \newacronym{suny}{SUNY}{State University of New York}
 \newacronym{surveymeans}{SURVEYMEANS}{SAS procedure for estimating characteristics of a survey population using statistics computed from a survey sample}
@@ -1102,7 +1102,7 @@
 \newacronym{whoi}{WHOI}{Woods Hole Oceanographic Institute, MA}
 \newacronym{winter calcofi}{Winter CalCOFI}{CalCOFI\_Winter}
 \newacronym{winter california cooperative fisheries investigations survey}{Winter California Cooperative Fisheries Investigations Survey}{CalCOFI\_Winter}
-\newacronym{winter northeast fisheries science center ecosystem monitoring survey}{Winter Northeast Fisheries Science Center Ecosystem Monitoring Survey}{Northeast Ecosystem Monitoring (EcoMon)\_Winter}
+\newacronym{winter nefsc ecosystem monitoring survey}{Winter Northeast Fisheries Science Center Ecosystem Monitoring Survey}{Northeast Ecosystem Monitoring (EcoMon)\_Winter}
 \newacronym{wpacfin}{WPacFIN}{Western Pacific Fishery Information Network, NMFS}
 \newacronym{wpfmc}{WPFMC}{Western Pacific Regional Fishery Management Council}
 \newacronym{wpue}{WPUE}{weight per unit effort}


### PR DESCRIPTION
<!---
Thanks for opening a PR. This commented text will **NOT** appear in the final PR. Toggle between Write and Preview to see what your PR will look like without the comments.
-->

# What is the feature?
* Shorten glossary labels by subbing FSC acronyms in for full names, as suggested in NEFSC workshop

# Does the PR impact any other area of the project, maybe another repo?
* No