### PR TITLE
[fix]: Remove duplicated acronyms from glossary

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: asar
 Title: Build NOAA Stock Assessment Report
-Version: 2.0.4
+Version: 2.0.5
 Authors@R: c(
     person("Samantha", "Schiano", , "samantha.schiano@noaa.gov", role = c("aut", "cre"),
            comment = c(ORCID = "0009-0003-3744-6428")),

--- a/R/export_glossary.R
+++ b/R/export_glossary.R
@@ -671,6 +671,7 @@ export_glossary <- function() {
     # remove duplicates
     dplyr::filter(
       !(Definition == "Aggregated Survey on US chartered and State-Owned boats" & Acronym == "ASOUCA"),
+      !(Meaning == "biomass maximum sustainable yield"),
       !(Meaning == "CAEP Cook Inlet Beluga USrvey_Summer" & Label == "cook inlet beluga (cib) demography and condition_uas"),
       !(Definition == "The Marine Resources Monitoring, Assessment, and Prediction Program" & Acronym == "MARMAP"),
       !(Meaning == "CalCOFI_Spring" & Acronym == "CS"),
@@ -681,6 +682,7 @@ export_glossary <- function() {
       !(Meaning == "biomass" & Label == "bm"),
       !(Meaning == "centimeters, fish length" & Label == "cm"),
       !(Meaning == "fishing mortality at 50% of msy" & Label == "fl"),
+      !(Meaning == "management track"),
       !(Meaning == "operational assessment, biennial" & Label == "oa"),
       !(Meaning == "Portable Document Format" & Label == "pdf"),
       !(Meaning == "Quantitative Ecology and Socioeconomics Training" & Label == "qus"),
@@ -735,7 +737,8 @@ export_glossary <- function() {
 
   duplicate_acronyms <- unique_all_cleaning3 |>
     dplyr::add_count(Acronym) |>
-    dplyr::filter(n > 1) |>
+    dplyr::add_count(Label) |>
+    dplyr::filter(n > 1 | nn > 1) |>
     dplyr::distinct()
 
   if (dim(duplicate_acronyms)[1] > 0) {

--- a/inst/glossary/report_glossary.tex
+++ b/inst/glossary/report_glossary.tex
@@ -111,7 +111,6 @@
 \newacronym{bm}{BM}{base model}
 \newacronym{bmrho}{BMrho}{biomass amount adjusted according to Mohn's rho value}
 \newacronym{bmsy}{$B_{MSY}$}{biomass at max sustainable yield}
-\newacronym{bmsy}{$B_{MSY}$}{biomass maximum sustainable yield}
 \newacronym{bmsypr}{$B_{MSY}pr$}{proxy estimate for biomass maximum sustainable yield}
 \newacronym{boem}{BOEM}{Bureau of Ocean Energy Management}
 \newacronym{bof}{BOF}{Board of Fish}
@@ -649,7 +648,6 @@
 \newacronym{msvpa}{MSVPA}{multispecies virtual population analysis}
 \newacronym{msvpa-x}{MSVPA-X}{Expanded multispecies virtual population analysis}
 \newacronym{msy}{$MSY$}{maximum sustainable yield}
-\newacronym{mt}{MT}{management track}
 \newacronym{mt}{mt}{metric ton}
 \newacronym{mta}{MTA}{Management Track Assessment}
 \newacronym{mus}{MUS}{management unit species}


### PR DESCRIPTION
<!---
Thanks for opening a PR. This commented text will **NOT** appear in the final PR. Toggle between Write and Preview to see what your PR will look like without the comments.
-->

# What is the feature?
* Remove two duplicates from glossary: bmsy and mt

# How have you implemented the solution?
* Updating `export_glossary()` and glossary tex file

# Does the PR impact any other area of the project, maybe another repo?
* No
