### PR TITLE
[fix] Update create_template() to find start of preamble

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: asar
 Title: Build NOAA Stock Assessment Report
-Version: 2.0.6
+Version: 2.0.7
 Authors@R: c(
     person("Samantha", "Schiano", , "samantha.schiano@noaa.gov", role = c("aut", "cre"),
            comment = c(ORCID = "0009-0003-3744-6428")),

--- a/R/create_template.R
+++ b/R/create_template.R
@@ -897,7 +897,7 @@ create_template <- function(
         question1 <- "n"
       }
       if (regexpr(question1, "n", ignore.case = TRUE) == 1) {
-        start_line <- grep("preamble", prev_skeleton) - 1
+        start_line <- grep("label: 'preamble'", prev_skeleton) - 1
         # find next trailing "```"` in case it was edited at the end
         end_line <- grep("```", prev_skeleton)[grep("```", prev_skeleton) > start_line][1]
         # preamble <- paste(prev_skeleton[start_line:end_line], collapse = "\n")


### PR DESCRIPTION
<!---
Thanks for opening a PR. This commented text will **NOT** appear in the final PR. Toggle between Write and Preview to see what your PR will look like without the comments.
-->

# What is the feature?
* Fix https://github.com/nmfs-ost/asar/issues/462

# How have you implemented the solution?
* In `create_template()`, update code that looks for the start of the preamble chunk so it finds it correctly and doesn't identify two lines with "preamble"

# Does the PR impact any other area of the project, maybe another repo?
* No