### PR TITLE
[test] Add tests for rending draft and accessible PDFs

### DIFF
--- a/tests/testthat/test-add_accessibility.R
+++ b/tests/testthat/test-add_accessibility.R
@@ -1,65 +1,42 @@
-# test_that("add_alttext() creates .tex file", {
-#   path <- getwd()
-#   # run convert_output for example model
-#   simple_model <- file.path(test_path("fixtures", "ss3_models"), "models", "Simple")
-#   stockplotr::convert_output(
-#     output_file = "Report.sso",
-#     outdir = simple_model,
-#     model = "SS3",
-#     file_save = TRUE,
-#     save_name = "spp_conout"
-#   ) |> suppressMessages() |> suppressWarnings()
-#
-#   # run stockplotr::exp_all_figs_tables()
-#   stockplotr::exp_all_figs_tables(
-#     dat = utils::read.csv(file.path(path, "spp_conout.csv")),
-#     end_year = 2023,
-#     ref_line = "msy",
-#     ref_line_sb = "msy",
-#     indices_unit_label = ""
-#   ) |> suppressMessages() |> suppressWarnings()
-#
-#   # run create template
-#   asar::create_template(
-#     office = "NWFSC",
-#     region = "USWC",
-#     species = "Big skate",
-#     spp_latin = "latin spp",
-#     year = 2025,
-#     author = "John Snow",
-#     resdir = path,
-#     model_results = "spp_conout.csv",
-#     model = "SS3"
-#   ) |> suppressMessages() |> suppressWarnings()
-#
-#   # render template
-#   quarto::quarto_render(file.path(path, "report", "SAR_USWC_Big_skate_skeleton.qmd"))
-#
-#   # run add_tagging and check if new one is created
-#     add_accessibility(
-#       x = "SAR_USWC_Big_skate_skeleton.tex",
-#       dir = file.path(getwd(), "report"),
-#       figures_dir = getwd(),
-#       compile = TRUE,
-#       alttext_csv_dir = getwd(),
-#       rename = "Simple_SAR_2025_a11y"
-#   )
-#
-#   # Remove testing files
-#   on.exit(unlink(file.path(getwd(), "report"),
-#       recursive = TRUE
-#     ), add = TRUE)
-#   on.exit(unlink(file.path(getwd(), "figures"),
-#       recursive = TRUE
-#     ), add = TRUE)
-#   on.exit(unlink(file.path(getwd(), "spp_conout.csv"),
-#     recursive = TRUE
-#   ), add = TRUE)
-#   on.exit(unlink(file.path(getwd(), "captions_alt_text.csv"),
-#     recursive = TRUE
-#   ), add = TRUE)
-#   on.exit(unlink(file.path(getwd(), "key_quantities.csv"),
-#     recursive = TRUE
-#   ), add = TRUE)
-# })
-#
+test_that("add_accessibility() runs without error", {
+  
+  stockplotr::plot_biomass(dat = stockplotr::example_data,
+                           interactive = FALSE,
+                           make_rda = TRUE)
+  create_template(
+    office = "NWFSC",
+    region = "USWC",
+    species = "Big skate",
+    year = 2025
+  ) |> suppressMessages() |> suppressWarnings()
+
+  # render template
+  quarto::quarto_render(file.path(getwd(), "report", "SAR_U_Big_skate_skeleton.qmd"))
+
+    expect_no_error(
+      add_accessibility(
+        x = "SAR_U_Big_skate_skeleton.tex",
+        dir = file.path(getwd(), "report"),
+        rename = "Simple_SAR_2025_a11y"
+      )
+    )
+    
+    expect_true(
+      file.exists(file.path(getwd(), "report", "Simple_SAR_2025_a11y.pdf"))
+    )
+
+  # Remove testing files
+  on.exit(unlink(file.path(getwd(), "report"),
+      recursive = TRUE
+    ), add = TRUE)
+  on.exit(unlink(file.path(getwd(), "figures"),
+      recursive = TRUE
+    ), add = TRUE)
+  on.exit(unlink(file.path(getwd(), "captions_alt_text.csv"),
+    recursive = TRUE
+  ), add = TRUE)
+  on.exit(unlink(file.path(getwd(), "key_quantities.csv"),
+    recursive = TRUE
+  ), add = TRUE)
+})
+

--- a/tests/testthat/test-add_accessibility.R
+++ b/tests/testthat/test-add_accessibility.R
@@ -1,4 +1,6 @@
 test_that("add_accessibility() runs without error", {
+  # don't run on GitHub because tinytex isn't installed in the GitHub testing environment, so rendering will fail
+  skip_on_ci()
   
   stockplotr::plot_biomass(dat = stockplotr::example_data,
                            interactive = FALSE,

--- a/tests/testthat/test-create_template.R
+++ b/tests/testthat/test-create_template.R
@@ -370,3 +370,38 @@ test_that("Incompatible formats are recognized, produce warnings/errors", {
   # erase temporary testing files
   unlink(fs::path(path, "report"), recursive = T)
 })
+
+test_that("Basic report renders", {
+
+  create_template(
+    office = "NWFSC",
+    species = "Dover sole",
+    year = 2010,
+    authors = c("John Snow" = "AFSC", "Danny Phantom" = "SWFSC", "Patrick Star" = "SEFSC")
+  )
+  
+  # add acronym and reference
+  exec_sum_path <- fs::path("report", "01_executive_summary.qmd")
+  exec_sum <- readLines(exec_sum_path) |>
+    suppressWarnings()
+
+  new_text <- append(exec_sum,
+                     paste0(
+                     "\n",
+                      "@Abrams2014 states that...\n",
+                      "\\gls{abc} is an acronym for..."))
+  writeLines(new_text, exec_sum_path)
+  
+  expect_no_error(
+    quarto::quarto_render(
+    input = fs::path(getwd(), "report", "sar_Dover_sole_skeleton.qmd")
+    )
+  )
+  
+  # Check report pdf created
+  expect_true(file.exists(fs::path(getwd(), "report", "Dover_sole_SAR_2010.pdf")))
+  
+  # erase temporary testing files
+  unlink(fs::path(getwd(), "report"), recursive = T)
+})
+

--- a/tests/testthat/test-create_template.R
+++ b/tests/testthat/test-create_template.R
@@ -375,12 +375,23 @@ test_that("Basic report renders", {
   # don't run on GitHub because tinytex isn't installed in the GitHub testing environment, so rendering will fail
   skip_on_ci()
 
+  out_new <- stockplotr::example_data
+  save(out_new,
+       file = fs::path("out_new.rda"))
+
   create_template(
     office = "NWFSC",
     species = "Dover sole",
+    model_results = "out_new.rda",
     year = 2010,
     authors = c("John Snow" = "AFSC", "Danny Phantom" = "SWFSC", "Patrick Star" = "SEFSC")
   )
+  
+  # move model results to "report" folder
+  file.copy(from = "out_new.rda",
+            to = fs::path(getwd(), "report", "out_new.rda"),)
+  
+  file.remove("out_new.rd")
   
   # add acronym and reference
   exec_sum_path <- fs::path("report", "01_executive_summary.qmd")
@@ -391,7 +402,10 @@ test_that("Basic report renders", {
                      paste0(
                      "\n",
                       "@Abrams2014 states that...\n",
-                      "\\gls{abc} is an acronym for..."))
+                      "\\gls{abc} is an acronym for...\n",
+                     "The end year is `r end_year`.\n",
+                     "The species is `r params$species`"
+                     ))
   writeLines(new_text, exec_sum_path)
   
   expect_no_error(

--- a/tests/testthat/test-create_template.R
+++ b/tests/testthat/test-create_template.R
@@ -372,6 +372,8 @@ test_that("Incompatible formats are recognized, produce warnings/errors", {
 })
 
 test_that("Basic report renders", {
+  # don't run on GitHub because tinytex isn't installed in the GitHub testing environment, so rendering will fail
+  skip_on_ci()
 
   create_template(
     office = "NWFSC",


### PR DESCRIPTION
<!---
Thanks for opening a PR. This commented text will **NOT** appear in the final PR. Toggle between Write and Preview to see what your PR will look like without the comments.
-->

# What is the feature?
* Add tests for rending draft and accessible PDFs
_Note:_ These tests will only run locally, since they rely on the `tinytex` installation. They won't run on GitHub.

# How have you implemented the solution?
* Adding tests for `add_accessibility()` and `create_template()`

# Does the PR impact any other area of the project, maybe another repo?
* No