### PR TITLE
[feat] Add chunk options to YAML

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: asar
 Title: Build NOAA Stock Assessment Report
-Version: 2.1.1
+Version: 2.2.0
 Authors@R: c(
     person("Samantha", "Schiano", , "samantha.schiano@noaa.gov", role = c("aut", "cre"),
            comment = c(ORCID = "0009-0003-3744-6428")),

--- a/R/add_chunk.R
+++ b/R/add_chunk.R
@@ -18,7 +18,7 @@ add_chunk <- function(
   x,
   label = NULL,
   add_option = TRUE,
-  chunk_option = c("echo: false", "warnings: false", "eval: true"),
+  chunk_option = c("warnings: false", "eval: true"),
   rmark_option = NULL
 ) {
   chunk <- paste0(

--- a/R/create_yaml.R
+++ b/R/create_yaml.R
@@ -213,7 +213,9 @@ create_yaml <- function(
       "date: today", "\n",
       # "lang: en \n",
       "keep-tex: true \n",
-      "mainfont: 'Latin Modern Sans' \n"
+      "mainfont: 'Latin Modern Sans' \n",
+      "tbl-pos: 't' \n",
+      "echo: false \n"
     )
 
     # Add species image on title page

--- a/tests/testthat/_snaps/add_chunk.md
+++ b/tests/testthat/_snaps/add_chunk.md
@@ -4,7 +4,6 @@
       cat(add_chunk("plot(cars$speed, cars$distance)"))
     Output
       ```{r} 
-      #| echo: false 
       #| warnings: false 
       #| eval: true
       plot(cars$speed, cars$distance)

--- a/tests/testthat/test-create_figures_doc.R
+++ b/tests/testthat/test-create_figures_doc.R
@@ -48,13 +48,13 @@ test_that("Creates expected start of figures doc with figure", {
 
   # read in figures doc
   figure_content <- readLines("09_figures.qmd")
-  # extract first 7 lines
-  head_figure_content <- head(figure_content, 7)
+  # extract first 6 lines
+  head_figure_content <- head(figure_content, 6)
   # remove line numbers and collapse
   fc_pasted <- paste(head_figure_content, collapse = "")
 
   # expected figures doc head
-  expected_head_figure_content <- "# Figures {#sec-figures} ```{r} #| label: 'set-rda-dir-figs'#| echo: false #| warnings: false #| eval: true"
+  expected_head_figure_content <- "# Figures {#sec-figures} ```{r} #| label: 'set-rda-dir-figs'#| warnings: false #| eval: true"
 
   # test expectation of start of figures doc
   expect_equal(
@@ -93,13 +93,13 @@ test_that("Formerly empty figures doc renders correctly", {
 
   # read in figures doc
   figure_content <- readLines(file.path(getwd(), "report", "09_figures.qmd"))
-  # extract first 8 lines
-  head_figure_content <- head(figure_content, 8)
+  # extract first 7 lines
+  head_figure_content <- head(figure_content, 7)
   # remove line numbers and collapse
   fc_pasted <- paste(head_figure_content, collapse = "")
 
   # expected figures doc head
-  expected_head_figure_content <- "# Figures {#sec-figures} ```{r} #| label: 'set-rda-dir-figs'#| echo: false #| warnings: false #| eval: true"
+  expected_head_figure_content <- "# Figures {#sec-figures} ```{r} #| label: 'set-rda-dir-figs'#| warnings: false #| eval: true"
 
   # test expectation of start of figures doc
   expect_equal(


### PR DESCRIPTION
<!---
Thanks for opening a PR. This commented text will **NOT** appear in the final PR. Toggle between Write and Preview to see what your PR will look like without the comments.
-->

# What is the feature?
* Add chunk options to skeleton YAML so that 1) tables are always at the top of the page, but not anchored in a way that interferes with the Tables header and 2) code doesn't show

# How have you implemented the solution?
* Add "echo" and "tbl-pos" chunk options into YAML and remove from add_chunk(); update tests

# Does the PR impact any other area of the project, maybe another repo?
* No
