### PR TITLE
[fix] Update 'office' param in YAML to include glossary syntax

### DIFF
--- a/R/create_yaml.R
+++ b/R/create_yaml.R
@@ -143,7 +143,7 @@ create_yaml <- function(
         yaml <- stringr::str_replace(yaml, yaml[grep("species: 'species'", yaml)], paste("  ", " ", "species: ", "'", species, "'", sep = ""))
       }
       if (length(office) == 1 & !is.null(office) & any(grepl("office: ''", yaml))) {
-        yaml <- stringr::str_replace(yaml, yaml[grep("office: ''", yaml)], paste("  ", " ", "office: ", "'", office, "'", sep = ""))
+        yaml <- stringr::str_replace(yaml, yaml[grep("office: ''", yaml)], paste("  ", " ", "office: ", "'\\gls{", tolower(office), "}'", sep = ""))
       }
       if (!is.null(spp_latin) & any(grepl("spp_latin: ''", yaml))) {
         yaml <- stringr::str_replace(yaml, yaml[grep("spp_latin: ''", yaml)], paste("  ", " ", "spp_latin: ", "'", spp_latin, "'", sep = ""))
@@ -268,7 +268,7 @@ create_yaml <- function(
     if (parameters) {
       yaml <- paste0(
         yaml, "params:", "\n",
-        "  ", " ", "office: ", "'", office, "'", "\n",
+        "  ", " ", "office: ", "'\\gls{", tolower(office), "}'", "\n",
         "  ", " ", "species: ", "'", species, "'", "\n",
         "  ", " ", "spp_latin: ", "'", spp_latin, "'", "\n",
         "  ", " ", "region: ", "'", region, "'", "\n"

--- a/R/export_glossary.R
+++ b/R/export_glossary.R
@@ -543,7 +543,8 @@ export_glossary <- function() {
       Meaning = ifelse(Meaning == "Spawning Abundance at MSY", "spawning abundance at MSY", Meaning),
       Meaning = ifelse(Meaning == "Spawning Stock Biomass at MSY", "spawning stock biomass at MSY", Meaning),
       Meaning = ifelse(Acronym == "R", "Programming environment for statistical processing and presentation", Meaning),
-      Meaning = ifelse(Acronym == "GARM", "Groundfish Assessment Review Meeting", Meaning)
+      Meaning = ifelse(Acronym == "GARM", "Groundfish Assessment Review Meeting", Meaning),
+      Meaning = ifelse(Acronym == "SWFSC", "Southwest Fisheries Science Center", Meaning)
     ) |>
     # add periods to end of Definition
     dplyr::mutate(

--- a/inst/glossary/report_glossary.tex
+++ b/inst/glossary/report_glossary.tex
@@ -1132,7 +1132,7 @@
 \newacronym{surveymeans}{SURVEYMEANS}{SAS procedure for estimating characteristics of a survey population using statistics computed from a survey sample}
 \newacronym{sw}{SW}{Southwest}
 \newacronym{swac}{SWAC}{seawater air conditioning}
-\newacronym{swfsc}{SWFSC}{Southwest Fisheries Science Center (NMFS)}
+\newacronym{swfsc}{SWFSC}{Southwest Fisheries Science Center}
 \newacronym{swg}{SWG}{shallow-water grouper}
 \newacronym{swo}{SWO}{swordfish}
 \newacronym{swr}{SWR}{Southwest Region}


### PR DESCRIPTION
# What is the feature?
* Update 'office' param in YAML to include glossary syntax, as it's an acronym, as per https://github.com/nmfs-ost/asar/issues/450
* update SWFSC entry in glossary

# How have you implemented the solution?
* Editing `create_yaml()` and glossary

# Does the PR impact any other area of the project, maybe another repo?
* No
