### PR TITLE
[feat]: Add a different species image on `rerender_skeleton = TRUE`

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: asar
 Title: Build NOAA Stock Assessment Report
-Version: 2.3.0
+Version: 2.4.0
 Authors@R: c(
     person("Samantha", "Schiano", , "samantha.schiano@noaa.gov", role = c("aut", "cre"),
            comment = c(ORCID = "0009-0003-3744-6428")),

--- a/R/create_template.R
+++ b/R/create_template.R
@@ -475,12 +475,13 @@ create_template <- function(
       ))
       )
       # Add in species image if updated in rerender
-      if (species != "species") {
+      if (!is.null(spp_image) || species != "species") {
         file.copy(spp_image, supdir, overwrite = FALSE) |> suppressWarnings()
         # Change path to spp image since finished copying for yaml
         if (file.exists(spp_image)) {
           spp_image <- file.path("support_files", paste0(gsub(" ", "_", species), ".png"))
         }
+        # TODO: add line that replaces the default text in the _titlepage in formatting files?
       }
       # if it is previously html and the rerender species html then need to copy over html formatting
       if (tolower(prev_format) != "html" & tolower(format) == "html") {

--- a/R/create_template.R
+++ b/R/create_template.R
@@ -259,7 +259,7 @@ create_template <- function(
       )
     }
     region_name <- ifelse(
-      !is.null(region) | !is.na(region),
+      region != "NA", # !is.null(region) | !is.na(region)
       toupper(stringr::str_c(stringr::str_extract_all(region, "\\b[A-Za-z]")[[1]], collapse = "")),
       stringr::str_extract(prev_report_name, "(?<=_)[A-Z]+(?=_)")
     )
@@ -283,7 +283,7 @@ create_template <- function(
     new_report_name <- paste0(
       type, "_",
       ifelse(
-        is.null(region) | is.na(region),
+        is.null(region) | is.na(region) | region == "NA",
         "",
         glue::glue("{region_name}_")
       ),
@@ -380,7 +380,7 @@ create_template <- function(
 
   # Create subdirectory for files
   subdir <- ifelse(
-    grepl("/report", file_dir),
+    grepl("/report", file_dir) || file_dir == "report",
     fs::path(file_dir),
     fs::path(file_dir, "report")
   )
@@ -434,7 +434,8 @@ create_template <- function(
     # format_files <- list(before_body_file, header_file)
 
     #### Links to files for yaml ----
-    spp_image <- ifelse(spp_image == "",
+    spp_image <- ifelse(
+      spp_image == "",
       system.file("resources", "spp_img", paste(gsub(" ", "_", species), ".png", sep = ""), package = "asar"),
       spp_image
     )
@@ -464,30 +465,30 @@ create_template <- function(
         prev_skeleton[grep("format:", prev_skeleton) + 1],
         "[a-z]+"
       )
-      year <- ifelse(is.na(as.numeric(stringr::str_extract(
-        prev_skeleton[grep("title:", prev_skeleton)],
-        "[0-9]+"
-      ))),
-      year,
-      as.numeric(stringr::str_extract(
-        prev_skeleton[grep("title:", prev_skeleton)],
-        "[0-9]+"
-      ))
+      year <- ifelse(
+        is.na(as.numeric(stringr::str_extract(
+          prev_skeleton[grep("title:", prev_skeleton)],
+          "[0-9]+"
+        ))),
+        year,
+        as.numeric(stringr::str_extract(
+          prev_skeleton[grep("title:", prev_skeleton)],
+          "[0-9]+"
+        ))
       )
       # Add in species image if updated in rerender
-      if (!is.null(spp_image) || species != "species") {
+      if (!is.null(spp_image)) {
         file.copy(spp_image, supdir, overwrite = FALSE) |> suppressWarnings()
         # Change path to spp image since finished copying for yaml
         if (file.exists(spp_image)) {
-          spp_image <- file.path("support_files", paste0(gsub(" ", "_", species), ".png"))
+          spp_image <- file.path("support_files", stringr::str_extract(spp_image, "(?<=/)[^/]+$"))
         }
-        # TODO: add line that replaces the default text in the _titlepage in formatting files?
       }
       # if it is previously html and the rerender species html then need to copy over html formatting
       if (tolower(prev_format) != "html" & tolower(format) == "html") {
         if (!file.exists(file.path(file_dir, "support_files", "theme.scss"))) file.copy(system.file("resources", "formatting_files", "theme.scss", package = "asar"), supdir, overwrite = FALSE) |> suppressWarnings()
       }
-      if (tolower(prev_format != "pdf" & tolower(format) == "pdf")) {
+      if (tolower(prev_format) != "pdf" & tolower(format) == "pdf") {
         if (is.null(species)) {
           species <- tolower(stringr::str_extract(
             prev_skeleton[grep("species: ", prev_skeleton)],
@@ -511,8 +512,6 @@ create_template <- function(
         if (!file.exists(file_dir, "support_files", "_titlepage.tex") | !is.null(species)) create_titlepage_tex(office = office, subdir = supdir, species = species)
         # customize in-header tex
         if (!file.exists(file_dir, "support_files", "in-header.tex") | !is.null(species)) create_inheader_tex(species = species, year = year, subdir = supdir)
-        # copy new spp image if updated
-        if (!is.null(species)) file.copy(spp_image, supdir, overwrite = FALSE) |> suppressWarnings()
       }
     } else {
       #### Copy template files to report folder ----
@@ -601,7 +600,7 @@ create_template <- function(
           )
         }
       } # close check for previous files & respective copying
-      prev_skeleton <- NULL
+      # prev_skeleton <- NULL
     } # close if rerender
 
     # created tables doc

--- a/R/create_yaml.R
+++ b/R/create_yaml.R
@@ -123,7 +123,7 @@ create_yaml <- function(
     # }
 
     # add in spp image/replace if specific
-    if (!is.null(spp_image) || species != "species") {
+    if (!is.null(spp_image)) {
       yaml <- stringr::str_replace(yaml, yaml[grep("cover: ", yaml)], paste("cover: ", spp_image, sep = ""))
     }
 

--- a/R/create_yaml.R
+++ b/R/create_yaml.R
@@ -122,8 +122,8 @@ create_yaml <- function(
     #   yaml <- append(yaml, add_params, after = grep("bibliography:", yaml) - 1)
     # }
 
-    # add in spp image
-    if (species != "species") {
+    # add in spp image/replace if specific
+    if (!is.null(spp_image) || species != "species") {
       yaml <- stringr::str_replace(yaml, yaml[grep("cover: ", yaml)], paste("cover: ", spp_image, sep = ""))
     }
 


### PR DESCRIPTION
<!---
Thanks for opening a PR. This commented text will **NOT** appear in the final PR. Toggle between Write and Preview to see what your PR will look like without the comments.
-->

# What is the feature?
* Users can change the cover image using spp_image when rerender_skeleton = TRUE

# How have you implemented the solution?
* adjusted the path and if statement conditions

# Does the PR impact any other area of the project, maybe another repo?
* no
