### PR TITLE
Combine param_names and param_values into one argument

### DIFF
--- a/.github/workflows/make_monthly_report.yml
+++ b/.github/workflows/make_monthly_report.yml
@@ -65,8 +65,7 @@ jobs:
             authors = c("Ann Chovy"="NWFSC"),
             include_affiliation = TRUE,
             simple_affiliation = FALSE,
-            param_names = c("nf","sf"),
-            param_values = c("North fleet", "South fleet"),
+            custom_params = c("nf" = "North fleet", "sf" = "South fleet"),
             model_results = here::here("readme_output.rda")
           )
           

--- a/R/create_template.R
+++ b/R/create_template.R
@@ -132,17 +132,12 @@
 #' 
 #' Default: NULL
 #' 
-#' @param param_names List of additional custom parameter names to include in
-#' the skeleton YAML. Parameters automatically included: office, region,
-#' species (each of which are listed as individual parameters for this function,
-#' above).
-#'  
-#' Default: NULL
-#'  
-#' @param param_values List of values associated with the order
-#' of parameter names. Parameters automatically included:
-#' office, region, species (each of which are listed as
-#' individual parameters for this function, above).
+#' @param custom_params Character vector of additional custom parameter 
+#' names and values to include in the skeleton YAML. For example, a 
+#' parameter "year2" and its value "2026" would have an entry of 
+#' `c("year2" = "2026")`. Parameters automatically included: office, region,
+#' species (each of which are listed as individual parameters for this
+#' function, above).
 #'  
 #' Default: NULL
 #' 
@@ -228,8 +223,7 @@
 #'   year = 2010,
 #'   authors = c("John Snow" = "NEFSC", "Danny Phantom" = "SWFSC", "Patrick Star" = "SEFSC-ML"),
 #'   title = "Management Track Assessments Spring 2024",
-#'   param_names = c("region2", "year2"),
-#'   param_values = c("my_region2", "2024"),
+#'   custom_params = c("region2" = "North Coast", "year2" = "2026"),
 #'   model_results = here::here("folder", "std_output.rda"),
 #'   new_section = "an_additional_section",
 #'   section_location = "before-discussion",
@@ -260,8 +254,7 @@ create_template <- function(
   custom_sections = NULL,
   new_section = NULL,
   section_location = NULL,
-  param_names = NULL,
-  param_values = NULL,
+  custom_params = NULL,
   ...
 ) {
   # Check input type
@@ -772,6 +765,8 @@ create_template <- function(
     # }
 
     parameters <- TRUE
+    param_names <- custom_params |> names()
+    param_values <- custom_params |> unname()
     
     yaml <- create_yaml(
       prev_format = prev_format,
@@ -786,8 +781,7 @@ create_template <- function(
       spp_latin = spp_latin,
       region = region,
       parameters = parameters,
-      param_names = param_names,
-      param_values = param_values,
+      custom_params = custom_params,
       bib_name = bib_name,
       bib_file = bib_file,
       year = year,

--- a/R/create_yaml.R
+++ b/R/create_yaml.R
@@ -47,8 +47,7 @@
 #'   region = NULL,
 #'   format = "pdf",
 #'   parameters = TRUE,
-#'   param_names = NULL,
-#'   param_values = NULL,
+#'   custom_params = NULL,
 #'   bib_file = "path/asar_references.bib",
 #'   bib_name = "asar_references.bib",
 #'   year = 2025
@@ -70,10 +69,13 @@ create_yaml <- function(
   prev_skeleton = NULL,
   prev_format = NULL,
   parameters = TRUE,
-  param_names = NULL,
-  param_values = NULL,
+  custom_params = NULL,
   type = "SAR"
 ) {
+  
+  param_names <- custom_params |> names()
+  param_values <- custom_params |> unname()
+  
   # check first if want to rerender current skeleton
   if (rerender_skeleton) {
     # Extract yaml from current template
@@ -157,7 +159,7 @@ create_yaml <- function(
       # TODO: add check for params not being replicated of default
       if (!is.null(param_names) | !is.null(param_values)) {
         if (length(param_names) != length(param_values)) {
-          print("Please define ALL parameter names (param_names) and values (param_values).")
+          print("Please define ALL parameter names and values in `custom_params`.")
         } else {
           add_params <- NULL
           for (i in seq_along(param_names)) {
@@ -283,7 +285,7 @@ create_yaml <- function(
       if (!is.null(param_names) & !is.null(param_values)) {
         # check there are the same number of names and values
         if (length(param_names) != length(param_values)) {
-          print("Please define ALL parameter names (param_names) and values (param_values).")
+          print("Please define ALL parameter names and values in `custom_params`.")
         } else {
           add_params <- NULL
           for (i in seq_along(param_names)) {

--- a/README.md
+++ b/README.md
@@ -90,8 +90,7 @@ asar::create_template(
   authors = c("Ian G. Taylor"="NWFSC", "Vladlena Gertseva"="NWFSC", "Nick Tolimieri"="NWFSC"),
   include_affiliation = TRUE,
   simple_affiliation = FALSE,
-  param_names = c("nf","sf"),
-  param_values = c("North fleet", "South fleet"),
+  custom_params = c("nf" = "North fleet", "sf" = "South fleet"),
   model_results = here::here("readme_output.rda")
 )
 ```

--- a/man/create_template.Rd
+++ b/man/create_template.Rd
@@ -25,8 +25,7 @@ create_template(
   custom_sections = NULL,
   new_section = NULL,
   section_location = NULL,
-  param_names = NULL,
-  param_values = NULL,
+  custom_params = NULL,
   ...
 )
 }
@@ -158,17 +157,12 @@ order of (sub)section names listed in the 'new_section' parameter.
 
 Default: NULL}
 
-\item{param_names}{List of additional custom parameter names to include in
-the skeleton YAML. Parameters automatically included: office, region,
-species (each of which are listed as individual parameters for this function,
-above).
-
-Default: NULL}
-
-\item{param_values}{List of values associated with the order
-of parameter names. Parameters automatically included:
-office, region, species (each of which are listed as
-individual parameters for this function, above).
+\item{custom_params}{Character vector of additional custom parameter
+names and values to include in the skeleton YAML. For example, a
+parameter "year2" and its value "2026" would have an entry of
+\code{c("year2" = "2026")}. Parameters automatically included: office, region,
+species (each of which are listed as individual parameters for this
+function, above).
 
 Default: NULL}
 
@@ -258,8 +252,7 @@ create_template(
   year = 2010,
   authors = c("John Snow" = "NEFSC", "Danny Phantom" = "SWFSC", "Patrick Star" = "SEFSC-ML"),
   title = "Management Track Assessments Spring 2024",
-  param_names = c("region2", "year2"),
-  param_values = c("my_region2", "2024"),
+  custom_params = c("region2" = "North Coast", "year2" = "2026"),
   model_results = here::here("folder", "std_output.rda"),
   new_section = "an_additional_section",
   section_location = "before-discussion",

--- a/man/create_yaml.Rd
+++ b/man/create_yaml.Rd
@@ -20,8 +20,7 @@ create_yaml(
   prev_skeleton = NULL,
   prev_format = NULL,
   parameters = TRUE,
-  param_names = NULL,
-  param_values = NULL,
+  custom_params = NULL,
   type = "SAR"
 )
 }
@@ -95,17 +94,12 @@ base R.}
 \item{prev_format}{The format that the previous skeleton was directed to
 render to. Parameter is inherited from create_template.}
 
-\item{param_names}{List of additional custom parameter names to include in
-the skeleton YAML. Parameters automatically included: office, region,
-species (each of which are listed as individual parameters for this function,
-above).
-
-Default: NULL}
-
-\item{param_values}{List of values associated with the order
-of parameter names. Parameters automatically included:
-office, region, species (each of which are listed as
-individual parameters for this function, above).
+\item{custom_params}{Character vector of additional custom parameter
+names and values to include in the skeleton YAML. For example, a
+parameter "year2" and its value "2026" would have an entry of
+\code{c("year2" = "2026")}. Parameters automatically included: office, region,
+species (each of which are listed as individual parameters for this
+function, above).
 
 Default: NULL}
 
@@ -148,8 +142,7 @@ create_yaml(
   region = NULL,
   format = "pdf",
   parameters = TRUE,
-  param_names = NULL,
-  param_values = NULL,
+  custom_params = NULL,
   bib_file = "path/asar_references.bib",
   bib_name = "asar_references.bib",
   year = 2025

--- a/vignettes/articles/example_reports.qmd
+++ b/vignettes/articles/example_reports.qmd
@@ -58,8 +58,7 @@ create_template(
   authors = c("Ann Chovy" = "NWFSC"),
   include_affiliation = TRUE,
   simple_affiliation = FALSE,
-  param_names = c("nf", "sf"),
-  param_values = c("North fleet", "South fleet"),
+  custom_params = c("nf" = "North fleet", "sf" = "South fleet"),
   model_results = here::here("readme_output.rda")
 )
 


### PR DESCRIPTION
# What is the feature?
* Combine param_names and param_values (in create_template() and create_yaml()) as one arg as per @BenWilliams-NOAA 's suggestion in https://github.com/nmfs-ost/asar/issues/441
* update documentation

# Does the PR impact any other area of the project, maybe another repo?
* No